### PR TITLE
Add Binance platform support

### DIFF
--- a/kolaBot/kola/bargain.py
+++ b/kolaBot/kola/bargain.py
@@ -11,6 +11,12 @@ from kolaBot.kola.secrets import LIVE_KEY, LIVE_SECRET, TEST_KEY, TEST_SECRET
 from kolaBot.kola.settings import (
     LIVE_URL,
     TEST_URL,
+    BINANCE_URL,
+    BINANCE_TEST_URL,
+    BINANCE_API_KEY,
+    BINANCE_API_SECRET,
+    BINANCE_TEST_API_KEY,
+    BINANCE_TEST_API_SECRET,
     SYMBOL,
     ORDERID_PREFIX,
     TIMEOUT,
@@ -70,8 +76,18 @@ class Bargain:
         self.live = live
         if self.live and dbo is None:
             baseUrl, apiKey, apiSecret = LIVE_URL, LIVE_KEY, LIVE_SECRET
+            b_url, b_key, b_secret = (
+                BINANCE_URL,
+                BINANCE_API_KEY,
+                BINANCE_API_SECRET,
+            )
         else:
             baseUrl, apiKey, apiSecret = TEST_URL, TEST_KEY, TEST_SECRET
+            b_url, b_key, b_secret = (
+                BINANCE_TEST_URL,
+                BINANCE_TEST_API_KEY,
+                BINANCE_TEST_API_SECRET,
+            )
 
         if dbo:
             self.crypto_api = dbo
@@ -91,7 +107,8 @@ class Bargain:
                     logger=self.logger,
                 )
             elif trading_plateform == "binance":
-                self.crypto_api = Binance()
+                self.crypto_api = Binance(api_key=b_key, api_secret=b_secret)
+                self.crypto_api.API_URL = b_url
             self.dbo = None
 
         self.logger.info(f"Fini init {self}")

--- a/kolaBot/kola/settings.py
+++ b/kolaBot/kola/settings.py
@@ -14,6 +14,16 @@ URL = "https://www.bitmex.com/api/v1/"
 LIVE_URL = "https://www.bitmex.com/api/v1/"
 TEST_URL = "https://testnet.bitmex.com/api/v1/"
 
+# Binance endpoints
+BINANCE_URL = "https://api.binance.com/api"
+BINANCE_TEST_URL = "https://testnet.binance.vision/api"
+
+# Binance API credentials placeholders
+BINANCE_API_KEY = ""
+BINANCE_API_SECRET = ""
+BINANCE_TEST_API_KEY = ""
+BINANCE_TEST_API_SECRET = ""
+
 # constante
 XBTSATOSHI = 10 ** -8
 

--- a/kolaBot/kola/utils/argfunc.py
+++ b/kolaBot/kola/utils/argfunc.py
@@ -211,6 +211,14 @@ def get_args():
         help=(f"Le fichier de sorti log."),
     )
     parser.add_argument(
+        "--platform",
+        "-P",
+        type=str,
+        default="bitmex",
+        choices=["bitmex", "binance"],
+        help=("Trading platform to use."),
+    )
+    parser.add_argument(
         "--liveRun",
         "-L",
         action="store_true",

--- a/kolaBot/multi_kola.py
+++ b/kolaBot/multi_kola.py
@@ -46,7 +46,14 @@ time.tzset()
 class MarketAuditeur:
     """Classe du Market Auditeur."""
 
-    def __init__(self, live: bool = False, dbo=None, logger=None, symbol=SYMBOL):
+    def __init__(
+        self,
+        live: bool = False,
+        dbo=None,
+        logger=None,
+        symbol=SYMBOL,
+        platform: str = "bitmex",
+    ):
         """
         Une classe  pour placer un ordre conditionné et sa trace sur bitmex.
         Place an order pair on symbol market.
@@ -63,6 +70,7 @@ class MarketAuditeur:
         self.stop: Optional[bool] = False
 
         self.symbol = symbol
+        self.trading_plateform = platform
 
         self.dbo = dbo  # dummy bitmex for test
 
@@ -86,7 +94,9 @@ class MarketAuditeur:
 
     def __repr__(self):
         """Représentation du Market auditeur."""
-        rep = f"Live={self.live}-{self.symbol}, log to {self.logger}"
+        rep = (
+            f"Live={self.live}-{self.symbol}({self.trading_plateform}), log to {self.logger}"
+        )
         if len(self.resultats):
             rep += f"Resultats={self.resultats}"
 
@@ -100,9 +110,13 @@ class MarketAuditeur:
         # canal échange ordre, serveur dispacheur
         self.fileDeConfirmation: Queue = Queue()
 
-        # connexion avec Bitmex
+        # connexion avec la plateforme d'échange
         self.brg: Bargain = Bargain(
-            live=self.live, logger=self.logger, dbo=self.dbo, symbol=self.symbol
+            live=self.live,
+            logger=self.logger,
+            dbo=self.dbo,
+            symbol=self.symbol,
+            trading_plateform=self.trading_plateform,
         )
         # Serveur dispacheur d'ordre
         self.chrs: Chronos = Chronos(
@@ -632,7 +646,13 @@ def main_prg():
         name=LOGNAME, sLL=args.logLevel, logFile=args.logFile, fmt_=LOGFMT
     )
     dbo = DummyBitMEX(up=0, logger=rlogger) if args.dummy else None
-    tma = MarketAuditeur(live=args.liveRun, dbo=dbo, logger=rlogger, symbol=args.symbol)
+    tma = MarketAuditeur(
+        live=args.liveRun,
+        dbo=dbo,
+        logger=rlogger,
+        symbol=args.symbol,
+        platform=args.platform,
+    )
     tma.start_server()
 
     try:

--- a/kolaBot/run_multi_kola.py
+++ b/kolaBot/run_multi_kola.py
@@ -23,6 +23,7 @@ class argsO:
         updatepause=10,
         logpause=600,
         dummy=False,
+        platform="bitmex",
         **kwargs,
     ):
         """Simulate the args from command line"""
@@ -33,6 +34,7 @@ class argsO:
         self.dummy = False if liverun else dummy
         self.updatePause = updatepause
         self.logPause = logpause
+        self.platform = platform
 
     def __repr__(self, long=False):
         """Represent the program."""
@@ -45,6 +47,7 @@ class argsO:
             "liveRun": self.liveRun,
             "dummy": self.dummy,
             "updatePause": self.updatePause,
+            "platform": self.platform,
         }
         return f"argsO {obj}"
 
@@ -64,7 +67,11 @@ def main_prg():
     dbo = DummyBitMEX(up=0, logger=logger) if cmdArgs.dummy else None
 
     tma = MarketAuditeur(
-        live=cmdArgs.liveRun, dbo=dbo, logger=logger, symbol=cmdArgs.symbol
+        live=cmdArgs.liveRun,
+        dbo=dbo,
+        logger=logger,
+        symbol=cmdArgs.symbol,
+        platform=cmdArgs.platform,
     )
     tma.start_server()
 
@@ -104,6 +111,15 @@ def get_cmd_args():
             f"Market to listen too. could be XBTM20 XBTU20 ADAU20 BCHM20 ETHUSD LTCM20"
         ),
     )
+    parser.add_argument(
+        "--platform",
+        "-P",
+        type=str,
+        default="bitmex",
+        choices=["bitmex", "binance"],
+        help=("Trading platform to use."),
+    )
+
 
     parser.add_argument(
         "--logLevel", "-l", type=str, default="INFO", help=("Le log level")


### PR DESCRIPTION
## Summary
- expand settings with Binance endpoints and API placeholders
- support trading platform selection in Bargain
- add `--platform` flag for CLI utilities
- wire platform choice through `MarketAuditeur`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*