### PR TITLE
Remove secrets dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,17 +174,17 @@ would recommand doing it as a pip editable module with:
     # install the package from local source
     pip install -e . 
 
-Add you API keys in \`kolaBitMEXBot/kola/secret.py\`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Set your API keys with environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This file it should contain your keys and secrets as for example:
+Create environment variables before running the bot. Expected variable names are::
 
-.. code:: example
+    BITMEX_KEY
+    BITMEX_SECRET
+    BITMEX_TEST_KEY
+    BITMEX_TEST_SECRET
 
-    LIVE_KEY = "zIKTHISISARANDOMKEYNHII3"
-    LIVE_SECRET = "HUMOI9OkK89aIoXDAND THIS IS A SECRET0KAthnauwKj0"
-    TEST_KEY = "THEn_XATESTgXOcfKEYbuttz"
-    TEST_SECRET = "ANDjmJ3tbACz12VERYnzJS7LONGrPKI3r4uSECRETMU2C4HO"
+You can load them from ``.env-dev`` or ``.env-prod`` using the ``load_env.sh`` helper script located at the repository root.
 
 Write your orders in the `morder.tsv <https://github.com/maliky/kolaBitMEXBot/blob/master/kolaBitMEXBot/morders.tsv>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -275,8 +275,8 @@ Core program files
     │   │   ├── orders.py  ->  functions to places limit, stop, limit if touched ...
     │   │   └── trailstop.py  ->  orders that follow price variation and update 
     │   ├── price.py  ->  object to follow the different prices indexes
-    │   ├── settings.py  ->  setting files (where your keys may be)
-    │   ├── secrets.py  ->  where API keys could be
+    │   ├── settings.py  ->  global configuration values
+    │   ├── load_env.sh  ->  helper to load API keys
     │   ├── types.py  ->  (new) types to start typing the programm
     │   └── utils
     │       ├── argfunc.py  ->  handle command line arguments

--- a/kolaBitMEXBot/kola/bargain.py
+++ b/kolaBitMEXBot/kola/bargain.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 
 from kolaBitMEXBot.kola.kolatypes import ordStatusT
 from kolaBitMEXBot.kola.custom_bitmex import BitMEX
-from kolaBitMEXBot.kola.secrets import LIVE_KEY, LIVE_SECRET, TEST_KEY, TEST_SECRET
+import os
 from kolaBitMEXBot.kola.settings import (
     LIVE_URL,
     TEST_URL,
@@ -64,9 +64,13 @@ class Bargain:
 
         self.live = live
         if self.live and dbo is None:
-            baseUrl, apiKey, apiSecret = LIVE_URL, LIVE_KEY, LIVE_SECRET
+            baseUrl = LIVE_URL
+            apiKey = os.getenv("BITMEX_KEY")
+            apiSecret = os.getenv("BITMEX_SECRET")
         else:
-            baseUrl, apiKey, apiSecret = TEST_URL, TEST_KEY, TEST_SECRET
+            baseUrl = TEST_URL
+            apiKey = os.getenv("BITMEX_TEST_KEY")
+            apiSecret = os.getenv("BITMEX_TEST_SECRET")
 
         if dbo:
             self.bto = dbo

--- a/load_env.sh
+++ b/load_env.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Load API credentials for kolaBitMEXBot
+# Usage: ./load_env.sh [prod|dev]
+FILE=".env-dev"
+[ "$1" = "prod" ] && FILE=".env-prod"
+if [ -f "$FILE" ]; then
+  set -a
+  . "$FILE"
+  set +a
+else
+  echo "Environment file $FILE not found" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- read BitMEX API keys from environment variables
- show how to set the variables in README
- add helper script `load_env.sh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_687d5ebb43c08323a2c5f7a61f2737c5