### PR TITLE
Switch to environment variables for API keys

### DIFF
--- a/.env-dev
+++ b/.env-dev
@@ -1,0 +1,9 @@
+# Example development environment
+BITMEX_KEY=dev-bitmex-key
+BITMEX_SECRET=dev-bitmex-secret
+BITMEX_TEST_KEY=dev-bitmex-test-key
+BITMEX_TEST_SECRET=dev-bitmex-test-secret
+BINANCE_KEY=dev-binance-key
+BINANCE_SECRET=dev-binance-secret
+BINANCE_TEST_KEY=dev-binance-test-key
+BINANCE_TEST_SECRET=dev-binance-test-secret

--- a/.env-prod
+++ b/.env-prod
@@ -1,0 +1,9 @@
+# Example production environment
+BITMEX_KEY=prod-bitmex-key
+BITMEX_SECRET=prod-bitmex-secret
+BITMEX_TEST_KEY=prod-bitmex-test-key
+BITMEX_TEST_SECRET=prod-bitmex-test-secret
+BINANCE_KEY=prod-binance-key
+BINANCE_SECRET=prod-binance-secret
+BINANCE_TEST_KEY=prod-binance-test-key
+BINANCE_TEST_SECRET=prod-binance-test-secret

--- a/README.rst
+++ b/README.rst
@@ -174,17 +174,29 @@ would recommand doing it as a pip editable module with:
     # install the package from local source
     pip install -e . 
 
-Add you API keys in \`kolaBot/kola/secret.py\`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Set your API keys with environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This file it should contain your keys and secrets as for example:
+Credentials are now read from the environment. Define at least the
+following variables before using the bot:
 
-.. code:: example
+.. code:: bash
 
-    LIVE_KEY = "zIKTHISISARANDOMKEYNHII3"
-    LIVE_SECRET = "HUMOI9OkK89aIoXDAND THIS IS A SECRET0KAthnauwKj0"
-    TEST_KEY = "THEn_XATESTgXOcfKEYbuttz"
-    TEST_SECRET = "ANDjmJ3tbACz12VERYnzJS7LONGrPKI3r4uSECRETMU2C4HO"
+    BITMEX_KEY=...            # live BitMEX API key
+    BITMEX_SECRET=...
+    BITMEX_TEST_KEY=...       # testnet BitMEX API key
+    BITMEX_TEST_SECRET=...
+    BINANCE_KEY=...
+    BINANCE_SECRET=...
+    BINANCE_TEST_KEY=...
+    BINANCE_TEST_SECRET=...
+
+You can use ``env.sh`` to load these from ``.env-dev`` or ``.env-prod``:
+
+.. code:: bash
+
+    source env.sh        # loads .env-dev
+    source env.sh prod   # loads .env-prod
 
 Write your orders in the `morder.tsv <https://github.com/maliky/kolaBot/blob/master/kolaBot/morders.tsv>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -276,7 +288,7 @@ Core program files
     │   │   └── trailstop.py  ->  orders that follow price variation and update 
     │   ├── price.py  ->  object to follow the different prices indexes
     │   ├── settings.py  ->  setting files (where your keys may be)
-    │   ├── secrets.py  ->  where API keys could be
+    │   ├── env.sh       ->  helper to load environment variables
     │   ├── types.py  ->  (new) types to start typing the programm
     │   └── utils
     │       ├── argfunc.py  ->  handle command line arguments
@@ -293,10 +305,11 @@ Core program files
     ├── multi_kola.py  ->  handle the (multiple runs) of one pair of orders 
     ├── pos_test.py  ->  (depreciated...)
     ├── run_multi_kola.py  ->  handle multiple pairs of orders (parse morders.tsv)
+    ├── env.sh       ->  source to load .env-dev or .env-prod
     └── tests
         └── utils.py
 
-    5 directories, 33 files
+    5 directories, 34 files
 
 Setup and annexes program files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Load environment variables for kolaBot
+# Usage: source env.sh [prod|dev]
+ENV_FILE=".env-dev"
+if [ "$1" = "prod" ]; then
+  ENV_FILE=".env-prod"
+fi
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+else
+  echo "Missing $ENV_FILE" >&2
+fi

--- a/kolaBot/kola/bargain.py
+++ b/kolaBot/kola/bargain.py
@@ -7,7 +7,12 @@ from copy import deepcopy
 
 from kolaBot.kola.kolatypes import ordStatusT
 from kolaBot.kola.bitmex_api.custom_api import BitMEX
-from kolaBot.kola.secrets import LIVE_KEY, LIVE_SECRET, TEST_KEY, TEST_SECRET
+import os
+
+LIVE_KEY = os.getenv("BITMEX_KEY", "")
+LIVE_SECRET = os.getenv("BITMEX_SECRET", "")
+TEST_KEY = os.getenv("BITMEX_TEST_KEY", "")
+TEST_SECRET = os.getenv("BITMEX_TEST_SECRET", "")
 from kolaBot.kola.settings import (
     LIVE_URL,
     TEST_URL,

--- a/kolaBot/kola/settings.py
+++ b/kolaBot/kola/settings.py
@@ -18,11 +18,13 @@ TEST_URL = "https://testnet.bitmex.com/api/v1/"
 BINANCE_URL = "https://api.binance.com/api"
 BINANCE_TEST_URL = "https://testnet.binance.vision/api"
 
-# Binance API credentials placeholders
-BINANCE_API_KEY = ""
-BINANCE_API_SECRET = ""
-BINANCE_TEST_API_KEY = ""
-BINANCE_TEST_API_SECRET = ""
+# Binance API credentials read from environment
+import os
+
+BINANCE_API_KEY = os.getenv("BINANCE_KEY", "")
+BINANCE_API_SECRET = os.getenv("BINANCE_SECRET", "")
+BINANCE_TEST_API_KEY = os.getenv("BINANCE_TEST_KEY", "")
+BINANCE_TEST_API_SECRET = os.getenv("BINANCE_TEST_SECRET", "")
 
 # constante
 XBTSATOSHI = 10 ** -8


### PR DESCRIPTION
## Summary
- read BitMEX and Binance credentials from environment variables
- document new variables in the README
- add helper `env.sh` and sample `.env-dev` and `.env-prod`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kolaBot.tests')*

------
https://chatgpt.com/codex/tasks/task_e_687d6a47335c8323972853066b2d6b25